### PR TITLE
feat: Add HCM Products Wrapper Model and Vaccine Data

### DIFF
--- a/apps/health_campaign_field_worker_app/lib/data/local_store/no_sql/schema/app_configuration.g.dart
+++ b/apps/health_campaign_field_worker_app/lib/data/local_store/no_sql/schema/app_configuration.g.dart
@@ -178,6 +178,12 @@ const AppConfigurationSchema = CollectionSchema(
       name: r'symptomsTypes',
       type: IsarType.objectList,
       target: r'SymptomsTypes',
+    ),
+    r'vaccination-data': PropertySchema(
+      id: 28,
+      name: r'vaccination-data',
+      type: IsarType.objectList,
+      target: r'VaccineData',
     )
   },
   estimateSize: _appConfigurationEstimateSize,
@@ -208,6 +214,7 @@ const AppConfigurationSchema = CollectionSchema(
     r'SymptomsTypes': SymptomsTypesSchema,
     r'SearchHouseHoldFilters': SearchHouseHoldFiltersSchema,
     r'SearchCLFFilters': SearchCLFFiltersSchema,
+    r'VaccineData': VaccineDataSchema,
     r'ReferralReasons': ReferralReasonsSchema,
     r'HouseStructureTypes': HouseStructureTypesSchema,
     r'RefusalReasons': RefusalReasonsSchema,
@@ -542,6 +549,20 @@ int _appConfigurationEstimateSize(
       }
     }
   }
+  {
+    final list = object.vaccinationData;
+    if (list != null) {
+      bytesCount += 3 + list.length * 3;
+      {
+        final offsets = allOffsets[VaccineData]!;
+        for (var i = 0; i < list.length; i++) {
+          final value = list[i];
+          bytesCount +=
+              VaccineDataSchema.estimateSize(value, offsets, allOffsets);
+        }
+      }
+    }
+  }
   return bytesCount;
 }
 
@@ -689,6 +710,12 @@ void _appConfigurationSerialize(
     SymptomsTypesSchema.serialize,
     object.symptomsTypes,
   );
+  writer.writeObjectList<VaccineData>(
+    offsets[28],
+    allOffsets,
+    VaccineDataSchema.serialize,
+    object.vaccinationData,
+  );
 }
 
 AppConfiguration _appConfigurationDeserialize(
@@ -835,6 +862,12 @@ AppConfiguration _appConfigurationDeserialize(
     SymptomsTypesSchema.deserialize,
     allOffsets,
     SymptomsTypes(),
+  );
+  object.vaccinationData = reader.readObjectList<VaccineData>(
+    offsets[28],
+    VaccineDataSchema.deserialize,
+    allOffsets,
+    VaccineData(),
   );
   return object;
 }
@@ -1007,6 +1040,13 @@ P _appConfigurationDeserializeProp<P>(
         SymptomsTypesSchema.deserialize,
         allOffsets,
         SymptomsTypes(),
+      )) as P;
+    case 28:
+      return (reader.readObjectList<VaccineData>(
+        offset,
+        VaccineDataSchema.deserialize,
+        allOffsets,
+        VaccineData(),
       )) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -4014,6 +4054,113 @@ extension AppConfigurationQueryFilter
       );
     });
   }
+
+  QueryBuilder<AppConfiguration, AppConfiguration, QAfterFilterCondition>
+      vaccinationDataIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'vaccination-data',
+      ));
+    });
+  }
+
+  QueryBuilder<AppConfiguration, AppConfiguration, QAfterFilterCondition>
+      vaccinationDataIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'vaccination-data',
+      ));
+    });
+  }
+
+  QueryBuilder<AppConfiguration, AppConfiguration, QAfterFilterCondition>
+      vaccinationDataLengthEqualTo(int length) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'vaccination-data',
+        length,
+        true,
+        length,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<AppConfiguration, AppConfiguration, QAfterFilterCondition>
+      vaccinationDataIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'vaccination-data',
+        0,
+        true,
+        0,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<AppConfiguration, AppConfiguration, QAfterFilterCondition>
+      vaccinationDataIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'vaccination-data',
+        0,
+        false,
+        999999,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<AppConfiguration, AppConfiguration, QAfterFilterCondition>
+      vaccinationDataLengthLessThan(
+    int length, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'vaccination-data',
+        0,
+        true,
+        length,
+        include,
+      );
+    });
+  }
+
+  QueryBuilder<AppConfiguration, AppConfiguration, QAfterFilterCondition>
+      vaccinationDataLengthGreaterThan(
+    int length, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'vaccination-data',
+        length,
+        include,
+        999999,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<AppConfiguration, AppConfiguration, QAfterFilterCondition>
+      vaccinationDataLengthBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'vaccination-data',
+        lower,
+        includeLower,
+        upper,
+        includeUpper,
+      );
+    });
+  }
 }
 
 extension AppConfigurationQueryObject
@@ -4171,6 +4318,13 @@ extension AppConfigurationQueryObject
       symptomsTypesElement(FilterQuery<SymptomsTypes> q) {
     return QueryBuilder.apply(this, (query) {
       return query.object(q, r'symptomsTypes');
+    });
+  }
+
+  QueryBuilder<AppConfiguration, AppConfiguration, QAfterFilterCondition>
+      vaccinationDataElement(FilterQuery<VaccineData> q) {
+    return QueryBuilder.apply(this, (query) {
+      return query.object(q, r'vaccination-data');
     });
   }
 }
@@ -4612,6 +4766,13 @@ extension AppConfigurationQueryProperty
       symptomsTypesProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'symptomsTypes');
+    });
+  }
+
+  QueryBuilder<AppConfiguration, List<VaccineData>?, QQueryOperations>
+      vaccinationDataProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'vaccination-data');
     });
   }
 }
@@ -5846,6 +6007,431 @@ extension IdTypeOptionsQueryFilter
 
 extension IdTypeOptionsQueryObject
     on QueryBuilder<IdTypeOptions, IdTypeOptions, QFilterCondition> {}
+
+// coverage:ignore-file
+// ignore_for_file: duplicate_ignore, non_constant_identifier_names, constant_identifier_names, invalid_use_of_protected_member, unnecessary_cast, prefer_const_constructors, lines_longer_than_80_chars, require_trailing_commas, inference_failure_on_function_invocation, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_checks, join_return_with_assignment, prefer_final_locals, avoid_js_rounded_ints, avoid_positional_boolean_parameters, always_specify_types
+
+const VaccineDataSchema = Schema(
+  name: r'VaccineData',
+  id: -5297014709083700593,
+  properties: {
+    r'active': PropertySchema(
+      id: 0,
+      name: r'active',
+      type: IsarType.bool,
+    ),
+    r'ageInDays': PropertySchema(
+      id: 1,
+      name: r'ageInDays',
+      type: IsarType.long,
+    ),
+    r'code': PropertySchema(
+      id: 2,
+      name: r'code',
+      type: IsarType.string,
+    ),
+    r'name': PropertySchema(
+      id: 3,
+      name: r'name',
+      type: IsarType.string,
+    )
+  },
+  estimateSize: _vaccineDataEstimateSize,
+  serialize: _vaccineDataSerialize,
+  deserialize: _vaccineDataDeserialize,
+  deserializeProp: _vaccineDataDeserializeProp,
+);
+
+int _vaccineDataEstimateSize(
+  VaccineData object,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  var bytesCount = offsets.last;
+  bytesCount += 3 + object.code.length * 3;
+  bytesCount += 3 + object.name.length * 3;
+  return bytesCount;
+}
+
+void _vaccineDataSerialize(
+  VaccineData object,
+  IsarWriter writer,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  writer.writeBool(offsets[0], object.active);
+  writer.writeLong(offsets[1], object.ageInDays);
+  writer.writeString(offsets[2], object.code);
+  writer.writeString(offsets[3], object.name);
+}
+
+VaccineData _vaccineDataDeserialize(
+  Id id,
+  IsarReader reader,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  final object = VaccineData();
+  object.active = reader.readBool(offsets[0]);
+  object.ageInDays = reader.readLong(offsets[1]);
+  object.code = reader.readString(offsets[2]);
+  object.name = reader.readString(offsets[3]);
+  return object;
+}
+
+P _vaccineDataDeserializeProp<P>(
+  IsarReader reader,
+  int propertyId,
+  int offset,
+  Map<Type, List<int>> allOffsets,
+) {
+  switch (propertyId) {
+    case 0:
+      return (reader.readBool(offset)) as P;
+    case 1:
+      return (reader.readLong(offset)) as P;
+    case 2:
+      return (reader.readString(offset)) as P;
+    case 3:
+      return (reader.readString(offset)) as P;
+    default:
+      throw IsarError('Unknown property with id $propertyId');
+  }
+}
+
+extension VaccineDataQueryFilter
+    on QueryBuilder<VaccineData, VaccineData, QFilterCondition> {
+  QueryBuilder<VaccineData, VaccineData, QAfterFilterCondition> activeEqualTo(
+      bool value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'active',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<VaccineData, VaccineData, QAfterFilterCondition>
+      ageInDaysEqualTo(int value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'ageInDays',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<VaccineData, VaccineData, QAfterFilterCondition>
+      ageInDaysGreaterThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'ageInDays',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<VaccineData, VaccineData, QAfterFilterCondition>
+      ageInDaysLessThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'ageInDays',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<VaccineData, VaccineData, QAfterFilterCondition>
+      ageInDaysBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'ageInDays',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<VaccineData, VaccineData, QAfterFilterCondition> codeEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'code',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<VaccineData, VaccineData, QAfterFilterCondition> codeGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'code',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<VaccineData, VaccineData, QAfterFilterCondition> codeLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'code',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<VaccineData, VaccineData, QAfterFilterCondition> codeBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'code',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<VaccineData, VaccineData, QAfterFilterCondition> codeStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'code',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<VaccineData, VaccineData, QAfterFilterCondition> codeEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'code',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<VaccineData, VaccineData, QAfterFilterCondition> codeContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'code',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<VaccineData, VaccineData, QAfterFilterCondition> codeMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'code',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<VaccineData, VaccineData, QAfterFilterCondition> codeIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'code',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<VaccineData, VaccineData, QAfterFilterCondition>
+      codeIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'code',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<VaccineData, VaccineData, QAfterFilterCondition> nameEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'name',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<VaccineData, VaccineData, QAfterFilterCondition> nameGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'name',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<VaccineData, VaccineData, QAfterFilterCondition> nameLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'name',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<VaccineData, VaccineData, QAfterFilterCondition> nameBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'name',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<VaccineData, VaccineData, QAfterFilterCondition> nameStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'name',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<VaccineData, VaccineData, QAfterFilterCondition> nameEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'name',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<VaccineData, VaccineData, QAfterFilterCondition> nameContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'name',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<VaccineData, VaccineData, QAfterFilterCondition> nameMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'name',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<VaccineData, VaccineData, QAfterFilterCondition> nameIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'name',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<VaccineData, VaccineData, QAfterFilterCondition>
+      nameIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'name',
+        value: '',
+      ));
+    });
+  }
+}
+
+extension VaccineDataQueryObject
+    on QueryBuilder<VaccineData, VaccineData, QFilterCondition> {}
 
 // coverage:ignore-file
 // ignore_for_file: duplicate_ignore, non_constant_identifier_names, constant_identifier_names, invalid_use_of_protected_member, unnecessary_cast, prefer_const_constructors, lines_longer_than_80_chars, require_trailing_commas, inference_failure_on_function_invocation, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_checks, join_return_with_assignment, prefer_final_locals, avoid_js_rounded_ints, avoid_positional_boolean_parameters, always_specify_types

--- a/apps/health_campaign_field_worker_app/lib/models/app_config/app_config_model.freezed.dart
+++ b/apps/health_campaign_field_worker_app/lib/models/app_config/app_config_model.freezed.dart
@@ -662,6 +662,9 @@ AppConfigPrimaryWrapperModel _$AppConfigPrimaryWrapperModelFromJson(
 mixin _$AppConfigPrimaryWrapperModel {
   @JsonKey(name: 'HCM')
   HCMWrapperModel? get hcmWrapperModel => throw _privateConstructorUsedError;
+  @JsonKey(name: 'HCM-PRODUCTS')
+  HCMProductsWrapperModel? get hcmProductsWrapperModel =>
+      throw _privateConstructorUsedError;
   @JsonKey(name: 'common-masters')
   CommonMastersWrapperModel? get commonMasters =>
       throw _privateConstructorUsedError;
@@ -684,10 +687,13 @@ abstract class $AppConfigPrimaryWrapperModelCopyWith<$Res> {
   @useResult
   $Res call(
       {@JsonKey(name: 'HCM') HCMWrapperModel? hcmWrapperModel,
+      @JsonKey(name: 'HCM-PRODUCTS')
+      HCMProductsWrapperModel? hcmProductsWrapperModel,
       @JsonKey(name: 'common-masters') CommonMastersWrapperModel? commonMasters,
       @JsonKey(name: 'module-version') RowVersionWrapperModel? rowVersions});
 
   $HCMWrapperModelCopyWith<$Res>? get hcmWrapperModel;
+  $HCMProductsWrapperModelCopyWith<$Res>? get hcmProductsWrapperModel;
   $CommonMastersWrapperModelCopyWith<$Res>? get commonMasters;
   $RowVersionWrapperModelCopyWith<$Res>? get rowVersions;
 }
@@ -707,6 +713,7 @@ class _$AppConfigPrimaryWrapperModelCopyWithImpl<$Res,
   @override
   $Res call({
     Object? hcmWrapperModel = freezed,
+    Object? hcmProductsWrapperModel = freezed,
     Object? commonMasters = freezed,
     Object? rowVersions = freezed,
   }) {
@@ -715,6 +722,10 @@ class _$AppConfigPrimaryWrapperModelCopyWithImpl<$Res,
           ? _value.hcmWrapperModel
           : hcmWrapperModel // ignore: cast_nullable_to_non_nullable
               as HCMWrapperModel?,
+      hcmProductsWrapperModel: freezed == hcmProductsWrapperModel
+          ? _value.hcmProductsWrapperModel
+          : hcmProductsWrapperModel // ignore: cast_nullable_to_non_nullable
+              as HCMProductsWrapperModel?,
       commonMasters: freezed == commonMasters
           ? _value.commonMasters
           : commonMasters // ignore: cast_nullable_to_non_nullable
@@ -735,6 +746,19 @@ class _$AppConfigPrimaryWrapperModelCopyWithImpl<$Res,
 
     return $HCMWrapperModelCopyWith<$Res>(_value.hcmWrapperModel!, (value) {
       return _then(_value.copyWith(hcmWrapperModel: value) as $Val);
+    });
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $HCMProductsWrapperModelCopyWith<$Res>? get hcmProductsWrapperModel {
+    if (_value.hcmProductsWrapperModel == null) {
+      return null;
+    }
+
+    return $HCMProductsWrapperModelCopyWith<$Res>(
+        _value.hcmProductsWrapperModel!, (value) {
+      return _then(_value.copyWith(hcmProductsWrapperModel: value) as $Val);
     });
   }
 
@@ -775,11 +799,15 @@ abstract class _$$AppConfigPrimaryWrapperModelImplCopyWith<$Res>
   @useResult
   $Res call(
       {@JsonKey(name: 'HCM') HCMWrapperModel? hcmWrapperModel,
+      @JsonKey(name: 'HCM-PRODUCTS')
+      HCMProductsWrapperModel? hcmProductsWrapperModel,
       @JsonKey(name: 'common-masters') CommonMastersWrapperModel? commonMasters,
       @JsonKey(name: 'module-version') RowVersionWrapperModel? rowVersions});
 
   @override
   $HCMWrapperModelCopyWith<$Res>? get hcmWrapperModel;
+  @override
+  $HCMProductsWrapperModelCopyWith<$Res>? get hcmProductsWrapperModel;
   @override
   $CommonMastersWrapperModelCopyWith<$Res>? get commonMasters;
   @override
@@ -800,6 +828,7 @@ class __$$AppConfigPrimaryWrapperModelImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? hcmWrapperModel = freezed,
+    Object? hcmProductsWrapperModel = freezed,
     Object? commonMasters = freezed,
     Object? rowVersions = freezed,
   }) {
@@ -808,6 +837,10 @@ class __$$AppConfigPrimaryWrapperModelImplCopyWithImpl<$Res>
           ? _value.hcmWrapperModel
           : hcmWrapperModel // ignore: cast_nullable_to_non_nullable
               as HCMWrapperModel?,
+      hcmProductsWrapperModel: freezed == hcmProductsWrapperModel
+          ? _value.hcmProductsWrapperModel
+          : hcmProductsWrapperModel // ignore: cast_nullable_to_non_nullable
+              as HCMProductsWrapperModel?,
       commonMasters: freezed == commonMasters
           ? _value.commonMasters
           : commonMasters // ignore: cast_nullable_to_non_nullable
@@ -826,6 +859,7 @@ class _$AppConfigPrimaryWrapperModelImpl
     implements _AppConfigPrimaryWrapperModel {
   const _$AppConfigPrimaryWrapperModelImpl(
       {@JsonKey(name: 'HCM') this.hcmWrapperModel,
+      @JsonKey(name: 'HCM-PRODUCTS') this.hcmProductsWrapperModel,
       @JsonKey(name: 'common-masters') this.commonMasters,
       @JsonKey(name: 'module-version') this.rowVersions});
 
@@ -837,6 +871,9 @@ class _$AppConfigPrimaryWrapperModelImpl
   @JsonKey(name: 'HCM')
   final HCMWrapperModel? hcmWrapperModel;
   @override
+  @JsonKey(name: 'HCM-PRODUCTS')
+  final HCMProductsWrapperModel? hcmProductsWrapperModel;
+  @override
   @JsonKey(name: 'common-masters')
   final CommonMastersWrapperModel? commonMasters;
   @override
@@ -845,7 +882,7 @@ class _$AppConfigPrimaryWrapperModelImpl
 
   @override
   String toString() {
-    return 'AppConfigPrimaryWrapperModel(hcmWrapperModel: $hcmWrapperModel, commonMasters: $commonMasters, rowVersions: $rowVersions)';
+    return 'AppConfigPrimaryWrapperModel(hcmWrapperModel: $hcmWrapperModel, hcmProductsWrapperModel: $hcmProductsWrapperModel, commonMasters: $commonMasters, rowVersions: $rowVersions)';
   }
 
   @override
@@ -855,6 +892,9 @@ class _$AppConfigPrimaryWrapperModelImpl
             other is _$AppConfigPrimaryWrapperModelImpl &&
             (identical(other.hcmWrapperModel, hcmWrapperModel) ||
                 other.hcmWrapperModel == hcmWrapperModel) &&
+            (identical(
+                    other.hcmProductsWrapperModel, hcmProductsWrapperModel) ||
+                other.hcmProductsWrapperModel == hcmProductsWrapperModel) &&
             (identical(other.commonMasters, commonMasters) ||
                 other.commonMasters == commonMasters) &&
             (identical(other.rowVersions, rowVersions) ||
@@ -863,8 +903,8 @@ class _$AppConfigPrimaryWrapperModelImpl
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, hcmWrapperModel, commonMasters, rowVersions);
+  int get hashCode => Object.hash(runtimeType, hcmWrapperModel,
+      hcmProductsWrapperModel, commonMasters, rowVersions);
 
   @JsonKey(ignore: true)
   @override
@@ -886,6 +926,8 @@ abstract class _AppConfigPrimaryWrapperModel
     implements AppConfigPrimaryWrapperModel {
   const factory _AppConfigPrimaryWrapperModel(
           {@JsonKey(name: 'HCM') final HCMWrapperModel? hcmWrapperModel,
+          @JsonKey(name: 'HCM-PRODUCTS')
+          final HCMProductsWrapperModel? hcmProductsWrapperModel,
           @JsonKey(name: 'common-masters')
           final CommonMastersWrapperModel? commonMasters,
           @JsonKey(name: 'module-version')
@@ -898,6 +940,9 @@ abstract class _AppConfigPrimaryWrapperModel
   @override
   @JsonKey(name: 'HCM')
   HCMWrapperModel? get hcmWrapperModel;
+  @override
+  @JsonKey(name: 'HCM-PRODUCTS')
+  HCMProductsWrapperModel? get hcmProductsWrapperModel;
   @override
   @JsonKey(name: 'common-masters')
   CommonMastersWrapperModel? get commonMasters;
@@ -1757,6 +1802,166 @@ abstract class _HCMWrapperModel implements HCMWrapperModel {
       throw _privateConstructorUsedError;
 }
 
+HCMProductsWrapperModel _$HCMProductsWrapperModelFromJson(
+    Map<String, dynamic> json) {
+  return _HCMProductsWrapperModel.fromJson(json);
+}
+
+/// @nodoc
+mixin _$HCMProductsWrapperModel {
+  @JsonKey(name: 'vaccination-data')
+  List<VaccineData> get vaccinationData => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $HCMProductsWrapperModelCopyWith<HCMProductsWrapperModel> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $HCMProductsWrapperModelCopyWith<$Res> {
+  factory $HCMProductsWrapperModelCopyWith(HCMProductsWrapperModel value,
+          $Res Function(HCMProductsWrapperModel) then) =
+      _$HCMProductsWrapperModelCopyWithImpl<$Res, HCMProductsWrapperModel>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'vaccination-data') List<VaccineData> vaccinationData});
+}
+
+/// @nodoc
+class _$HCMProductsWrapperModelCopyWithImpl<$Res,
+        $Val extends HCMProductsWrapperModel>
+    implements $HCMProductsWrapperModelCopyWith<$Res> {
+  _$HCMProductsWrapperModelCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? vaccinationData = null,
+  }) {
+    return _then(_value.copyWith(
+      vaccinationData: null == vaccinationData
+          ? _value.vaccinationData
+          : vaccinationData // ignore: cast_nullable_to_non_nullable
+              as List<VaccineData>,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$HCMProductsWrapperModelImplCopyWith<$Res>
+    implements $HCMProductsWrapperModelCopyWith<$Res> {
+  factory _$$HCMProductsWrapperModelImplCopyWith(
+          _$HCMProductsWrapperModelImpl value,
+          $Res Function(_$HCMProductsWrapperModelImpl) then) =
+      __$$HCMProductsWrapperModelImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'vaccination-data') List<VaccineData> vaccinationData});
+}
+
+/// @nodoc
+class __$$HCMProductsWrapperModelImplCopyWithImpl<$Res>
+    extends _$HCMProductsWrapperModelCopyWithImpl<$Res,
+        _$HCMProductsWrapperModelImpl>
+    implements _$$HCMProductsWrapperModelImplCopyWith<$Res> {
+  __$$HCMProductsWrapperModelImplCopyWithImpl(
+      _$HCMProductsWrapperModelImpl _value,
+      $Res Function(_$HCMProductsWrapperModelImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? vaccinationData = null,
+  }) {
+    return _then(_$HCMProductsWrapperModelImpl(
+      vaccinationData: null == vaccinationData
+          ? _value._vaccinationData
+          : vaccinationData // ignore: cast_nullable_to_non_nullable
+              as List<VaccineData>,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$HCMProductsWrapperModelImpl implements _HCMProductsWrapperModel {
+  const _$HCMProductsWrapperModelImpl(
+      {@JsonKey(name: 'vaccination-data')
+      required final List<VaccineData> vaccinationData})
+      : _vaccinationData = vaccinationData;
+
+  factory _$HCMProductsWrapperModelImpl.fromJson(Map<String, dynamic> json) =>
+      _$$HCMProductsWrapperModelImplFromJson(json);
+
+  final List<VaccineData> _vaccinationData;
+  @override
+  @JsonKey(name: 'vaccination-data')
+  List<VaccineData> get vaccinationData {
+    if (_vaccinationData is EqualUnmodifiableListView) return _vaccinationData;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_vaccinationData);
+  }
+
+  @override
+  String toString() {
+    return 'HCMProductsWrapperModel(vaccinationData: $vaccinationData)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$HCMProductsWrapperModelImpl &&
+            const DeepCollectionEquality()
+                .equals(other._vaccinationData, _vaccinationData));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, const DeepCollectionEquality().hash(_vaccinationData));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$HCMProductsWrapperModelImplCopyWith<_$HCMProductsWrapperModelImpl>
+      get copyWith => __$$HCMProductsWrapperModelImplCopyWithImpl<
+          _$HCMProductsWrapperModelImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$HCMProductsWrapperModelImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _HCMProductsWrapperModel implements HCMProductsWrapperModel {
+  const factory _HCMProductsWrapperModel(
+          {@JsonKey(name: 'vaccination-data')
+          required final List<VaccineData> vaccinationData}) =
+      _$HCMProductsWrapperModelImpl;
+
+  factory _HCMProductsWrapperModel.fromJson(Map<String, dynamic> json) =
+      _$HCMProductsWrapperModelImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'vaccination-data')
+  List<VaccineData> get vaccinationData;
+  @override
+  @JsonKey(ignore: true)
+  _$$HCMProductsWrapperModelImplCopyWith<_$HCMProductsWrapperModelImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
 AppConfigSecondaryWrapperModel _$AppConfigSecondaryWrapperModelFromJson(
     Map<String, dynamic> json) {
   return _AppConfigSecondaryWrapperModel.fromJson(json);
@@ -2343,6 +2548,201 @@ abstract class _CommonMasterModel implements CommonMasterModel {
   @override
   @JsonKey(ignore: true)
   _$$CommonMasterModelImplCopyWith<_$CommonMasterModelImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+VaccineData _$VaccineDataFromJson(Map<String, dynamic> json) {
+  return _VaccineData.fromJson(json);
+}
+
+/// @nodoc
+mixin _$VaccineData {
+// required String id,
+  String get code => throw _privateConstructorUsedError;
+  String get name => throw _privateConstructorUsedError;
+  bool get active => throw _privateConstructorUsedError;
+  int get ageInDays => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $VaccineDataCopyWith<VaccineData> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $VaccineDataCopyWith<$Res> {
+  factory $VaccineDataCopyWith(
+          VaccineData value, $Res Function(VaccineData) then) =
+      _$VaccineDataCopyWithImpl<$Res, VaccineData>;
+  @useResult
+  $Res call({String code, String name, bool active, int ageInDays});
+}
+
+/// @nodoc
+class _$VaccineDataCopyWithImpl<$Res, $Val extends VaccineData>
+    implements $VaccineDataCopyWith<$Res> {
+  _$VaccineDataCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? code = null,
+    Object? name = null,
+    Object? active = null,
+    Object? ageInDays = null,
+  }) {
+    return _then(_value.copyWith(
+      code: null == code
+          ? _value.code
+          : code // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      active: null == active
+          ? _value.active
+          : active // ignore: cast_nullable_to_non_nullable
+              as bool,
+      ageInDays: null == ageInDays
+          ? _value.ageInDays
+          : ageInDays // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$VaccineDataImplCopyWith<$Res>
+    implements $VaccineDataCopyWith<$Res> {
+  factory _$$VaccineDataImplCopyWith(
+          _$VaccineDataImpl value, $Res Function(_$VaccineDataImpl) then) =
+      __$$VaccineDataImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String code, String name, bool active, int ageInDays});
+}
+
+/// @nodoc
+class __$$VaccineDataImplCopyWithImpl<$Res>
+    extends _$VaccineDataCopyWithImpl<$Res, _$VaccineDataImpl>
+    implements _$$VaccineDataImplCopyWith<$Res> {
+  __$$VaccineDataImplCopyWithImpl(
+      _$VaccineDataImpl _value, $Res Function(_$VaccineDataImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? code = null,
+    Object? name = null,
+    Object? active = null,
+    Object? ageInDays = null,
+  }) {
+    return _then(_$VaccineDataImpl(
+      code: null == code
+          ? _value.code
+          : code // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      active: null == active
+          ? _value.active
+          : active // ignore: cast_nullable_to_non_nullable
+              as bool,
+      ageInDays: null == ageInDays
+          ? _value.ageInDays
+          : ageInDays // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$VaccineDataImpl implements _VaccineData {
+  const _$VaccineDataImpl(
+      {required this.code,
+      required this.name,
+      required this.active,
+      required this.ageInDays});
+
+  factory _$VaccineDataImpl.fromJson(Map<String, dynamic> json) =>
+      _$$VaccineDataImplFromJson(json);
+
+// required String id,
+  @override
+  final String code;
+  @override
+  final String name;
+  @override
+  final bool active;
+  @override
+  final int ageInDays;
+
+  @override
+  String toString() {
+    return 'VaccineData(code: $code, name: $name, active: $active, ageInDays: $ageInDays)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VaccineDataImpl &&
+            (identical(other.code, code) || other.code == code) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.active, active) || other.active == active) &&
+            (identical(other.ageInDays, ageInDays) ||
+                other.ageInDays == ageInDays));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, code, name, active, ageInDays);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$VaccineDataImplCopyWith<_$VaccineDataImpl> get copyWith =>
+      __$$VaccineDataImplCopyWithImpl<_$VaccineDataImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$VaccineDataImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _VaccineData implements VaccineData {
+  const factory _VaccineData(
+      {required final String code,
+      required final String name,
+      required final bool active,
+      required final int ageInDays}) = _$VaccineDataImpl;
+
+  factory _VaccineData.fromJson(Map<String, dynamic> json) =
+      _$VaccineDataImpl.fromJson;
+
+  @override // required String id,
+  String get code;
+  @override
+  String get name;
+  @override
+  bool get active;
+  @override
+  int get ageInDays;
+  @override
+  @JsonKey(ignore: true)
+  _$$VaccineDataImplCopyWith<_$VaccineDataImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 

--- a/apps/health_campaign_field_worker_app/lib/models/app_config/app_config_model.g.dart
+++ b/apps/health_campaign_field_worker_app/lib/models/app_config/app_config_model.g.dart
@@ -69,6 +69,10 @@ _$AppConfigPrimaryWrapperModelImpl _$$AppConfigPrimaryWrapperModelImplFromJson(
       hcmWrapperModel: json['HCM'] == null
           ? null
           : HCMWrapperModel.fromJson(json['HCM'] as Map<String, dynamic>),
+      hcmProductsWrapperModel: json['HCM-PRODUCTS'] == null
+          ? null
+          : HCMProductsWrapperModel.fromJson(
+              json['HCM-PRODUCTS'] as Map<String, dynamic>),
       commonMasters: json['common-masters'] == null
           ? null
           : CommonMastersWrapperModel.fromJson(
@@ -83,6 +87,7 @@ Map<String, dynamic> _$$AppConfigPrimaryWrapperModelImplToJson(
         _$AppConfigPrimaryWrapperModelImpl instance) =>
     <String, dynamic>{
       'HCM': instance.hcmWrapperModel,
+      'HCM-PRODUCTS': instance.hcmProductsWrapperModel,
       'common-masters': instance.commonMasters,
       'module-version': instance.rowVersions,
     };
@@ -184,6 +189,20 @@ Map<String, dynamic> _$$HCMWrapperModelImplToJson(
       'FIREBASE_CONFIG': instance.firebaseConfig,
     };
 
+_$HCMProductsWrapperModelImpl _$$HCMProductsWrapperModelImplFromJson(
+        Map<String, dynamic> json) =>
+    _$HCMProductsWrapperModelImpl(
+      vaccinationData: (json['vaccination-data'] as List<dynamic>)
+          .map((e) => VaccineData.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$$HCMProductsWrapperModelImplToJson(
+        _$HCMProductsWrapperModelImpl instance) =>
+    <String, dynamic>{
+      'vaccination-data': instance.vaccinationData,
+    };
+
 _$AppConfigSecondaryWrapperModelImpl
     _$$AppConfigSecondaryWrapperModelImplFromJson(Map<String, dynamic> json) =>
         _$AppConfigSecondaryWrapperModelImpl(
@@ -234,6 +253,22 @@ Map<String, dynamic> _$$CommonMasterModelImplToJson(
       'code': instance.code,
       'name': instance.name,
       'active': instance.active,
+    };
+
+_$VaccineDataImpl _$$VaccineDataImplFromJson(Map<String, dynamic> json) =>
+    _$VaccineDataImpl(
+      code: json['code'] as String,
+      name: json['name'] as String,
+      active: json['active'] as bool,
+      ageInDays: (json['ageInDays'] as num).toInt(),
+    );
+
+Map<String, dynamic> _$$VaccineDataImplToJson(_$VaccineDataImpl instance) =>
+    <String, dynamic>{
+      'code': instance.code,
+      'name': instance.name,
+      'active': instance.active,
+      'ageInDays': instance.ageInDays,
     };
 
 _$StateInfoModelImpl _$$StateInfoModelImplFromJson(Map<String, dynamic> json) =>

--- a/apps/health_campaign_field_worker_app/lib/models/entities/mdms_master_enums.mapper.dart
+++ b/apps/health_campaign_field_worker_app/lib/models/entities/mdms_master_enums.mapper.dart
@@ -51,6 +51,8 @@ class MasterEnumsMapper extends EnumMapper<MasterEnums> {
         return MasterEnums.idTypes;
       case "DELIVERY_COMMENT_OPTIONS_POPULATOR":
         return MasterEnums.deliveryComments;
+      case "vaccination-data":
+        return MasterEnums.vaccinationData;
       case "BACKEND_INTERFACE":
         return MasterEnums.backendInterface;
       case "CALL_SUPPORT":
@@ -109,6 +111,8 @@ class MasterEnumsMapper extends EnumMapper<MasterEnums> {
         return "ID_TYPE_OPTIONS_POPULATOR";
       case MasterEnums.deliveryComments:
         return "DELIVERY_COMMENT_OPTIONS_POPULATOR";
+      case MasterEnums.vaccinationData:
+        return "vaccination-data";
       case MasterEnums.backendInterface:
         return "BACKEND_INTERFACE";
       case MasterEnums.callSupport:

--- a/apps/health_campaign_field_worker_app/lib/models/entities/mdms_module_enums.mapper.dart
+++ b/apps/health_campaign_field_worker_app/lib/models/entities/mdms_module_enums.mapper.dart
@@ -35,6 +35,8 @@ class ModuleEnumsMapper extends EnumMapper<ModuleEnums> {
         return ModuleEnums.moduleVersion;
       case "RAINMAKER-PGR":
         return ModuleEnums.rainmakerPgr;
+      case "HCM-PRODUCTS":
+        return ModuleEnums.hcmProducts;
       default:
         throw MapperException.unknownEnumValue(value);
     }
@@ -53,6 +55,8 @@ class ModuleEnumsMapper extends EnumMapper<ModuleEnums> {
         return "module-version";
       case ModuleEnums.rainmakerPgr:
         return "RAINMAKER-PGR";
+      case ModuleEnums.hcmProducts:
+        return "HCM-PRODUCTS";
     }
   }
 }

--- a/apps/health_campaign_field_worker_app/lib/pages/inventory/custom_stock_details.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/inventory/custom_stock_details.dart
@@ -106,6 +106,7 @@ class CustomStockDetailsPageState
       _partialBlistersKey: FormControl<int>(),
       _wastedBlistersKey: FormControl<int>(),
       _waybillQuantityKey: FormControl<String>(),
+      _batchNumberKey: FormControl<String>(),
       _vehicleNumberKey: FormControl<String>(),
       _typeOfTransportKey: FormControl<String>(),
       _commentsKey: FormControl<String>(),
@@ -438,6 +439,10 @@ class CustomStockDetailsPageState
                                           .control(_waybillQuantityKey)
                                           .value as String?;
 
+                                      final batchNumber = form
+                                          .control(_waybillQuantityKey)
+                                          .value as String?;
+
                                       final vehicleNumber = form
                                           .control(_vehicleNumberKey)
                                           .value as String?;
@@ -595,6 +600,7 @@ class CustomStockDetailsPageState
                                         ),
                                         additionalFields: [
                                                   waybillQuantity,
+                                                  batchNumber,
                                                   vehicleNumber,
                                                   comments,
                                                 ].any((element) =>
@@ -618,6 +624,14 @@ class CustomStockDetailsPageState
                                                     AdditionalField(
                                                       'waybill_quantity',
                                                       waybillQuantity,
+                                                    ),
+                                                  if (batchNumber != null &&
+                                                      batchNumber
+                                                          .trim()
+                                                          .isNotEmpty)
+                                                    AdditionalField(
+                                                      'batch_number',
+                                                      batchNumber,
                                                     ),
                                                   if (vehicleNumber != null &&
                                                       vehicleNumber
@@ -1519,6 +1533,28 @@ class CustomStockDetailsPageState
                                         label: localizations.translate(
                                           i18.stockDetails
                                               .quantityOfProductIndicatedOnWaybillLabel,
+                                        ),
+                                        onChange: (val) {
+                                          if (val == '') {
+                                            field.control.value = '0';
+                                          } else {
+                                            field.control.value = val;
+                                          }
+                                        },
+                                      );
+                                    }),
+                              if (isWareHouseMgr)
+                                ReactiveWrapperField(
+                                    formControlName: _batchNumberKey,
+                                    builder: (field) {
+                                      return InputField(
+                                        keyboardType: const TextInputType
+                                            .numberWithOptions(
+                                          decimal: true,
+                                        ),
+                                        type: InputType.numeric,
+                                        label: localizations.translate(
+                                          i18.stockDetails.batchNumberLabel,
                                         ),
                                         onChange: (val) {
                                           if (val == '') {

--- a/apps/health_campaign_field_worker_app/lib/pages/registration_delivery/custom_individual_details.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/registration_delivery/custom_individual_details.dart
@@ -1056,7 +1056,6 @@ class CustomIndividualDetailsPageState
 
         Validators.minLength(8),
         Validators.maxLength(8),
-        if (widget.isHeadOfHousehold) Validators.required,
         // Validators.required,
       ]),
     });


### PR DESCRIPTION
- Introduced HCMProductsWrapperModel to handle vaccination data.
- Updated AppConfigPrimaryWrapperModel to include hcmProductsWrapperModel.
- Implemented serialization and deserialization for HCMProductsWrapperModel and VaccineData.
- Enhanced MasterEnumsMapper and ModuleEnumsMapper to support new enums related to vaccination data.
- Added batch number field in CustomStockDetailsPage for inventory management.
- Removed unnecessary required validator for head of household in CustomIndividualDetailsPage.
- Updated pubspec.lock to reflect changes in dependencies.