### PR TITLE
fix: task edit, RDT flow, closed household, side-effect search, and v…

### DIFF
--- a/apps/health_campaign_field_worker_app/lib/pages/beneficiary/check_eligibility/check_eligibility_assessment.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/beneficiary/check_eligibility/check_eligibility_assessment.dart
@@ -73,6 +73,10 @@ class _EligibilityChecklistViewPage
   final String no = "NO";
   final String negative = "NEGATIVE";
   final String test_unavailable = "TEST_UNAVAILABLE";
+  static const String _kbea2Key = "KBEA2";
+  static const String _kbea3Key = "KBEA3";
+  static const String _kbea4Key = "KBEA4";
+  static const String _rdtResultKey = "KBEA2.YES.KBEA2A";
   bool triggerLocalization = false;
 
   @override
@@ -763,7 +767,9 @@ class _EligibilityChecklistViewPage
                                           ),
                                         ] else if (e.dataType ==
                                             'SingleValueList') ...[
-                                          if (!(e.code ?? '').contains('.'))
+                                          if (!(e.code ?? '').contains('.') &&
+                                              _shouldShowSpaqQuestionsForCode(
+                                                  e.code))
                                             DigitCard(
                                               child: _buildChecklist(
                                                 e,
@@ -809,7 +815,8 @@ class _EligibilityChecklistViewPage
 
       // Ensure the current index is added to visible indexes and not excluded
       if (!visibleChecklistIndexes.contains(index) &&
-          !excludedIndexes.contains(index)) {
+          !excludedIndexes.contains(index) &&
+          _shouldShowSpaqQuestionsForCode(item.code)) {
         visibleChecklistIndexes.add(index);
       }
 
@@ -859,7 +866,11 @@ class _EligibilityChecklistViewPage
                           ),
                         ).value;
 
-                        // Remove corresponding controllers based on the removed attributes
+                        if (item.code == _rdtResultKey) {
+                          _updateSpaqQuestionsVisibility(value);
+                        } else if (item.code == _kbea2Key && value != yes) {
+                          _showSpaqQuestions();
+                        }
                       });
                     },
                     items: item.values != null
@@ -1078,12 +1089,15 @@ class _EligibilityChecklistViewPage
     };
 
     if (responses.isNotEmpty) {
-      if (responses.containsKey(q3Key) && responses[q3Key]!.isNotEmpty) {
-        isIneligible = responses[q3Key] == yes ? true : false;
-      }
-      if (!isIneligible &&
-          (responses.containsKey(q5Key) && responses[q5Key]!.isNotEmpty)) {
-        isIneligible = responses[q5Key] == yes ? true : false;
+      final skipSpaqQuestions = _isRdtPositiveFromResponses(responses);
+      if (!skipSpaqQuestions) {
+        if (responses.containsKey(q3Key) && responses[q3Key]!.isNotEmpty) {
+          isIneligible = responses[q3Key] == yes ? true : false;
+        }
+        if (!isIneligible &&
+            (responses.containsKey(q5Key) && responses[q5Key]!.isNotEmpty)) {
+          isIneligible = responses[q5Key] == yes ? true : false;
+        }
       }
       if (responses.containsKey(q2Key) &&
           responses[q2Key]!.isNotEmpty &&
@@ -1094,7 +1108,7 @@ class _EligibilityChecklistViewPage
           isIneligible = responses[q6Key] == yes ? true : false;
         }
       }
-      if (isIneligible) {
+      if (isIneligible && !_isRdtPositiveFromResponses(responses)) {
         for (var entry in responses.entries) {
           if (entry.key == q3Key || entry.key == q5Key) {
             entry.value == yes
@@ -1273,6 +1287,57 @@ class _EligibilityChecklistViewPage
     }
 
     return dotCount;
+  }
+
+  int? _indexForAttributeCode(String code) {
+    final attributes = initialAttributes;
+    if (attributes == null) return null;
+    final index = attributes.indexWhere((a) => a.code == code);
+    return index >= 0 ? index : null;
+  }
+
+  bool _isRdtPositive() {
+    final kbea2Index = _indexForAttributeCode(_kbea2Key);
+    final rdtIndex = _indexForAttributeCode(_rdtResultKey);
+    if (kbea2Index == null || rdtIndex == null) return false;
+    return controller[kbea2Index].text.trim() == yes &&
+        controller[rdtIndex].text.trim() == positive;
+  }
+
+  bool _isRdtPositiveFromResponses(Map<String?, String> responses) {
+    return responses[_kbea2Key] == yes &&
+        responses[_rdtResultKey] == positive;
+  }
+
+  bool _shouldShowSpaqQuestionsForCode(String? code) {
+    if (code == _kbea3Key || code == _kbea4Key) {
+      return !_isRdtPositive();
+    }
+    return true;
+  }
+
+  void _updateSpaqQuestionsVisibility(String? rdtValue) {
+    final kbea3Index = _indexForAttributeCode(_kbea3Key);
+    final kbea4Index = _indexForAttributeCode(_kbea4Key);
+    if (rdtValue == positive) {
+      for (final index in [kbea3Index, kbea4Index]) {
+        if (index != null) {
+          visibleChecklistIndexes.remove(index);
+          controller[index].clear();
+        }
+      }
+    } else {
+      _showSpaqQuestions();
+    }
+  }
+
+  void _showSpaqQuestions() {
+    for (final code in [_kbea3Key, _kbea4Key]) {
+      final index = _indexForAttributeCode(code);
+      if (index != null && !visibleChecklistIndexes.contains(index)) {
+        visibleChecklistIndexes.add(index);
+      }
+    }
   }
 
   Future<bool> _onBackPressed(BuildContext context, bool isIneligible) async {

--- a/apps/health_campaign_field_worker_app/lib/pages/beneficiary/check_eligibility/vaccine_selection_page.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/beneficiary/check_eligibility/vaccine_selection_page.dart
@@ -342,6 +342,22 @@ class _VaccineSelectionPageState extends LocalizedState<VaccineSelectionPage> {
     return true;
   }
 
+  void _goToPreviousVaccineGroup() {
+    if (currentIndex > 0) {
+      setState(() {
+        currentIndex--;
+      });
+    }
+  }
+
+  Widget _buildBackHeader(BuildContext context) {
+    return CustomBackNavigationHelpHeaderWidget(
+      showHelp: false,
+      defaultPopRoute: currentIndex == 0,
+      handleback: currentIndex > 0 ? _goToPreviousVaccineGroup : null,
+    );
+  }
+
   String _numberToWords(int number) {
     // Simple mapping for numbers 0-6, extend as needed
     const words = [
@@ -594,11 +610,16 @@ class _VaccineSelectionPageState extends LocalizedState<VaccineSelectionPage> {
         }
 
         if (currentIndex < lastIndex) {
-          return ScrollableContent(
-            header: const Column(children: [
-              CustomBackNavigationHelpHeaderWidget(
-                showHelp: false,
-              )
+          return PopScope(
+            canPop: currentIndex == 0,
+            onPopInvoked: (didPop) {
+              if (!didPop && currentIndex > 0) {
+                _goToPreviousVaccineGroup();
+              }
+            },
+            child: ScrollableContent(
+            header: Column(children: [
+              _buildBackHeader(context),
             ]),
             enableFixedDigitButton: true,
             footer: DigitCard(
@@ -643,11 +664,17 @@ class _VaccineSelectionPageState extends LocalizedState<VaccineSelectionPage> {
                 vaccineCodes: currentVaccineCodes,
               ),
             ],
+          ),
           );
         }
 
         return PopScope(
-            canPop: true,
+            canPop: currentIndex == 0,
+            onPopInvoked: (didPop) {
+              if (!didPop && currentIndex > 0) {
+                _goToPreviousVaccineGroup();
+              }
+            },
             child: Scaffold(body: BlocBuilder<LocationBloc, LocationState>(
                 builder: (context, locationState) {
               return BlocBuilder<HouseholdOverviewBloc, HouseholdOverviewState>(
@@ -690,10 +717,8 @@ class _VaccineSelectionPageState extends LocalizedState<VaccineSelectionPage> {
                         orElse: () => Text(state.runtimeType.toString()),
                         serviceDefinitionFetch: (value) {
                           return ScrollableContent(
-                            header: const Column(children: [
-                              CustomBackNavigationHelpHeaderWidget(
-                                showHelp: false,
-                              )
+                            header: Column(children: [
+                              _buildBackHeader(context),
                             ]),
                             enableFixedDigitButton: true,
                             footer: DigitCard(

--- a/apps/health_campaign_field_worker_app/lib/pages/edit/task_details.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/edit/task_details.dart
@@ -5,10 +5,12 @@ import 'package:digit_data_model/data_model.dart';
 import 'package:digit_ui_components/models/DropdownModels.dart';
 import 'package:digit_ui_components/theme/digit_extended_theme.dart';
 import 'package:digit_ui_components/theme/spacers.dart';
+import 'package:digit_ui_components/digit_components.dart' hide LabeledField;
 import 'package:digit_ui_components/utils/date_utils.dart';
 import 'package:digit_ui_components/widgets/atoms/digit_dropdown_input.dart'
     as digit_ui;
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:provider/provider.dart';
 import 'package:registration_delivery/registration_delivery.dart';
@@ -54,6 +56,17 @@ class _TaskDetailPageState extends LocalizedState<TaskDetailPage> {
 
   bool _saving = false;
   late bool showResources;
+
+  static const _hiddenAdditionalFieldKeys = {
+    'dateOfAdministration',
+    'dateOfVerification',
+  };
+
+  static const _editableAdditionalFieldKeys = {'name', 'age'};
+
+  static const _genderFieldKey = 'gender';
+
+  static const _datePickerAdditionalFieldKeys = {'dateOfDelivery'};
 
   List<String> allowedStatuses = [
     Status.delivered.toValue(),
@@ -145,10 +158,11 @@ class _TaskDetailPageState extends LocalizedState<TaskDetailPage> {
 
     final fieldsList = _additionalFields?.fields ?? [];
 
-    // Exclude cycleIndex, doseIndex, and dateOfAdministration from editable additional fields
     _additionalFieldControllers = {
       for (final field in fieldsList)
-        field.key: TextEditingController(text: field.value?.toString() ?? '')
+        if (!_hiddenAdditionalFieldKeys.contains(field.key))
+          field.key:
+              TextEditingController(text: field.value?.toString() ?? '')
     };
   }
 
@@ -420,6 +434,15 @@ class _TaskDetailPageState extends LocalizedState<TaskDetailPage> {
       }
     }
 
+    // Apply edits from additional field controllers
+    updatedFields = updatedFields.map((field) {
+      final controller = _additionalFieldControllers[field.key];
+      if (controller != null) {
+        return AdditionalField(field.key, controller.text);
+      }
+      return field;
+    }).toList();
+
     // Remove any existing editCount and updateReason before adding updated ones
     updatedFields = updatedFields
         .where((f) => f.key != 'editCount' && f.key != 'updateReason')
@@ -545,6 +568,9 @@ class _TaskDetailPageState extends LocalizedState<TaskDetailPage> {
           lastModifiedTime: DateTime.now().millisecondsSinceEpoch,
         );
 
+    final parsedCreatedDate =
+        int.tryParse(_controllers['createdDate']?.text.trim() ?? '');
+
     // Create updated task model
     final updatedTask = task.copyWith(
       status: changeStatus
@@ -552,6 +578,7 @@ class _TaskDetailPageState extends LocalizedState<TaskDetailPage> {
               ? _controllers['status']!.text
               : task.status)
           : task.status,
+      createdDate: parsedCreatedDate ?? task.createdDate,
       additionalFields: newAdditionalFields,
       resources: updatedResources,
       clientAuditDetails: updatedClientAuditDetails,
@@ -890,10 +917,14 @@ class _TaskDetailPageState extends LocalizedState<TaskDetailPage> {
               ),
             )
           : SingleChildScrollView(
-              padding: const EdgeInsets.fromLTRB(spacer4, spacer2, spacer4, spacer4),
+              padding:
+                  const EdgeInsets.fromLTRB(spacer4, spacer2, spacer4, spacer4),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
+                  _buildEditableFieldsBanner(),
+                  const SizedBox(height: 16),
+
                   // Beneficiary Details Section
                   if (_individual != null) ...[
                     _buildIndividualDetailsSection(),
@@ -1146,7 +1177,8 @@ class _TaskDetailPageState extends LocalizedState<TaskDetailPage> {
 
           // Product Variant Dropdown
           if (productVariants != null && productVariants!.isNotEmpty)
-            LabeledField(
+            _wrapEditableField(
+              child: LabeledField(
               label:
                   localizations.translate(i18.editTasks.productVariantIdLabel),
               labelStyle: TextStyle(
@@ -1177,6 +1209,7 @@ class _TaskDetailPageState extends LocalizedState<TaskDetailPage> {
                   }
                 },
               ),
+            ),
             )
           else
             Text(
@@ -1277,11 +1310,7 @@ class _TaskDetailPageState extends LocalizedState<TaskDetailPage> {
             ..._additionalFieldControllers.entries.map((entry) {
               return Padding(
                 padding: const EdgeInsets.only(bottom: 12),
-                child: CustomDigitTextField(
-                  label: _formatFieldLabel(entry.key),
-                  controller: entry.value,
-                  readOnly: true,
-                ),
+                child: _buildAdditionalFieldWidget(entry.key, entry.value),
               );
             }),
           ],
@@ -1327,7 +1356,8 @@ class _TaskDetailPageState extends LocalizedState<TaskDetailPage> {
               ],
             ),
             const SizedBox(height: 8),
-            LabeledField(
+            _wrapEditableField(
+              child: LabeledField(
               label: localizations.translate(i18.editTasks.statusLabel),
               labelStyle: TextStyle(
                 color: theme.colorTheme.text.secondary,
@@ -1361,37 +1391,38 @@ class _TaskDetailPageState extends LocalizedState<TaskDetailPage> {
                 },
               ),
             ),
-            const SizedBox(height: 12),
-            Row(
-              children: [
-                Expanded(
-                  child: CustomDigitTextField(
-                    label:
-                        localizations.translate(i18.editTasks.createdByLabel),
-                    controller: _controllers['createdBy'],
-                    readOnly: true,
-                  ),
-                ),
-              ],
             ),
+            // const SizedBox(height: 12),
+            // Row(
+            //   children: [
+            //     Expanded(
+            //       child: CustomDigitTextField(
+            //         label:
+            //             localizations.translate(i18.editTasks.createdByLabel),
+            //         controller: _controllers['createdBy'],
+            //         readOnly: true,
+            //       ),
+            //     ),
+            //   ],
+            // ),
             const SizedBox(height: 12),
             Row(
               children: [
+                // Expanded(
+                //   child: CustomDigitTextField(
+                //     label:
+                //         localizations.translate(i18.editTasks.isDeletedLabel),
+                //     controller: _controllers['isDeleted'],
+                //     readOnly: true,
+                //   ),
+                // ),
+                // const SizedBox(width: 8),
                 Expanded(
-                  child: CustomDigitTextField(
-                    label:
-                        localizations.translate(i18.editTasks.isDeletedLabel),
-                    controller: _controllers['isDeleted'],
-                    readOnly: true,
-                  ),
-                ),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: CustomDigitTextField(
-                    label:
-                        localizations.translate(i18.editTasks.createdDateLabel),
-                    controller: _controllers['createdDate'],
-                    readOnly: true,
+                  child: _buildDatePickerField(
+                    label: localizations
+                        .translate(i18.editTasks.createdDateLabel),
+                    controller: _controllers['createdDate']!,
+                    showEditableBadge: true,
                   ),
                 ),
               ],
@@ -1454,6 +1485,269 @@ class _TaskDetailPageState extends LocalizedState<TaskDetailPage> {
         .split('_')
         .map((word) => word[0].toUpperCase() + word.substring(1))
         .join(' ');
+  }
+
+  bool _isAdditionalFieldEditable(String key) {
+    return _editableAdditionalFieldKeys.contains(key) ||
+        key == _genderFieldKey ||
+        _datePickerAdditionalFieldKeys.contains(key);
+  }
+
+  List<String> _allEditableFieldLabels() {
+    final labels = <String>[
+      localizations.translate(i18.editTasks.statusLabel),
+      localizations.translate(i18.editTasks.createdDateLabel),
+      _formatFieldLabel('name'),
+      _formatFieldLabel('age'),
+      localizations.translate(i18.editTasks.genderLabel),
+      _formatFieldLabel('dateOfDelivery'),
+    ];
+    if (showResources) {
+      labels.insert(
+        1,
+        localizations.translate(i18.editTasks.productVariantIdLabel),
+      );
+    }
+    return labels;
+  }
+
+  Widget _buildEditableFieldsBanner() {
+    final theme = Theme.of(context);
+    final textTheme = theme.digitTextTheme(context);
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: theme.colorTheme.primary.primary2.withOpacity(0.08),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: theme.colorTheme.primary.primary2.withOpacity(0.35),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(
+                Icons.edit_note,
+                color: theme.colorTheme.primary.primary2,
+                size: 22,
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  localizations
+                      .translate(i18.editTasks.editableFieldsHintTitle),
+                  style: textTheme.headingS.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: theme.colorTheme.primary.primary2,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: _allEditableFieldLabels()
+                .map(
+                  (label) => Chip(
+                    avatar: Icon(
+                      Icons.edit,
+                      size: 16,
+                      color: theme.colorTheme.primary.primary2,
+                    ),
+                    label: Text(label),
+                    labelStyle: textTheme.bodyS.copyWith(
+                      fontWeight: FontWeight.w500,
+                    ),
+                    backgroundColor:
+                        theme.colorTheme.paper.primary.withOpacity(0.9),
+                    side: BorderSide(
+                      color: theme.colorTheme.primary.primary2.withOpacity(0.4),
+                    ),
+                  ),
+                )
+                .toList(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _wrapEditableField({required Widget child}) {
+    final theme = Theme.of(context);
+    final textTheme = theme.digitTextTheme(context);
+    final badgeLabel =
+        localizations.translate(i18.editTasks.editableFieldBadge);
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: theme.colorTheme.primary.primary2.withOpacity(0.35),
+        ),
+        color: theme.colorTheme.primary.primary2.withOpacity(0.04),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(
+                Icons.edit,
+                size: 14,
+                color: theme.colorTheme.primary.primary2,
+              ),
+              const SizedBox(width: 4),
+              Text(
+                badgeLabel,
+                style: textTheme.bodyS.copyWith(
+                  color: theme.colorTheme.primary.primary2,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          child,
+        ],
+      ),
+    );
+  }
+
+  List<String> _genderOptions() {
+    return RegistrationDeliverySingleton().genderOptions ??
+        const ['MALE', 'FEMALE', 'OTHER'];
+  }
+
+  String _normalizeGenderCode(String value) => value.trim().toUpperCase();
+
+  Widget _buildGenderDropdown(TextEditingController controller) {
+    final theme = Theme.of(context);
+    final options = _genderOptions();
+    final selectedCode = _normalizeGenderCode(controller.text);
+
+    return _wrapEditableField(
+      child: LabeledField(
+        label: localizations.translate(i18.editTasks.genderLabel),
+        labelStyle: TextStyle(
+          color: theme.colorTheme.text.secondary,
+          fontSize: 16,
+        ),
+        child: digit_ui.DigitDropdown(
+          isDisabled: false,
+          readOnly: false,
+          selectedOption: options
+                  .map(
+                    (code) => DropdownItem(
+                      code: _normalizeGenderCode(code),
+                      name: localizations.translate(code),
+                    ),
+                  )
+                  .where((item) => item.code == selectedCode)
+                  .firstOrNull ??
+              DropdownItem(
+                code: selectedCode,
+                name: selectedCode.isNotEmpty
+                    ? localizations.translate(selectedCode)
+                    : localizations.translate(i18.editTasks.genderLabel),
+              ),
+          items: options
+              .map(
+                (code) => DropdownItem(
+                  code: _normalizeGenderCode(code),
+                  name: localizations.translate(code),
+                ),
+              )
+              .toList(),
+          onSelect: (selected) {
+            if (selected != null) {
+              setState(() {
+                controller.text = selected.code;
+              });
+            }
+          },
+        ),
+      ),
+    );
+  }
+
+  String _datePickerInitialValue(TextEditingController controller) {
+    final millis = int.tryParse(controller.text.trim());
+    if (millis != null) {
+      return local_utils.formatDateFromMillis(millis);
+    }
+    final date = DigitDateUtils.getFormattedDateToDateTime(controller.text);
+    if (date != null) {
+      return DateFormat('dd MMM yyyy').format(date);
+    }
+    return controller.text;
+  }
+
+  Widget _buildDatePickerField({
+    required String label,
+    required TextEditingController controller,
+    bool readOnly = false,
+    bool showEditableBadge = false,
+  }) {
+    final field = LabeledField(
+      label: label,
+      labelStyle: TextStyle(
+        color: Theme.of(context).colorTheme.text.secondary,
+        fontSize: 16,
+      ),
+      child: DigitDateFormInput(
+        readOnly: readOnly,
+        initialValue: _datePickerInitialValue(controller),
+        lastDate: DateTime.now(),
+        cancelText: localizations.translate(i18.common.coreCommonCancel),
+        confirmText: localizations.translate(i18.common.coreCommonOk),
+        onChange: (value) {
+          if (value.isEmpty) return;
+          final date = DigitDateUtils.getFormattedDateToDateTime(value) ??
+              DateFormat('dd/MM/yyyy').tryParse(value);
+          if (date != null) {
+            controller.text = date.millisecondsSinceEpoch.toString();
+          }
+        },
+      ),
+    );
+
+    return showEditableBadge ? _wrapEditableField(child: field) : field;
+  }
+
+  Widget _buildAdditionalFieldWidget(
+    String key,
+    TextEditingController controller,
+  ) {
+    final label = _formatFieldLabel(key);
+    final isEditable = _isAdditionalFieldEditable(key);
+
+    if (key == _genderFieldKey) {
+      return _buildGenderDropdown(controller);
+    }
+
+    Widget field;
+
+    if (_datePickerAdditionalFieldKeys.contains(key)) {
+      field = _buildDatePickerField(
+        label: label,
+        controller: controller,
+      );
+    } else {
+      field = CustomDigitTextField(
+        label: label,
+        controller: controller,
+        readOnly: !isEditable,
+      );
+    }
+
+    return isEditable ? _wrapEditableField(child: field) : field;
   }
 
   String? getSku(String variantId) {

--- a/apps/health_campaign_field_worker_app/lib/pages/referral_reconcillation/custom_record_referral_details.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/referral_reconcillation/custom_record_referral_details.dart
@@ -112,6 +112,21 @@ class _CustomRecordReferralDetailsPageState
         .abs();
   }
 
+  String _individualDisplayName(IndividualModel individual) {
+    return [
+      individual.name?.givenName,
+      individual.name?.familyName,
+    ].whereType<String>().where((e) => e.isNotEmpty).join(' ');
+  }
+
+  String? _individualBeneficiaryId(IndividualModel individual) {
+    return individual.identifiers
+        ?.firstWhereOrNull(
+          (id) => id.identifierType == 'UNIQUE_BENEFICIARY_ID',
+        )
+        ?.identifierId;
+  }
+
   @override
   void dispose() {
     clickedStatus.dispose();
@@ -155,6 +170,19 @@ class _CustomRecordReferralDetailsPageState
                       // may fire before individual is non-null.
                       final isSideEffect = _isSideEffectMode(recordState);
                       if (isSideEffect && individual != null) {
+                        final displayName =
+                            _individualDisplayName(individual);
+                        if (displayName.isNotEmpty &&
+                            form.control(_nameOfChildKey).value !=
+                                displayName) {
+                          form.control(_nameOfChildKey).value = displayName;
+                        }
+                        final benefId =
+                            _individualBeneficiaryId(individual);
+                        if (benefId != null &&
+                            form.control(_beneficiaryIdKey).value != benefId) {
+                          form.control(_beneficiaryIdKey).value = benefId;
+                        }
                         // Gender — genderOptions are uppercase codes (e.g. 'MALE'),
                         // but individual.gender?.name is lowercase enum name.
                         // Uppercase it so the Dropdown.selectedOption match works.
@@ -1274,23 +1302,26 @@ class _CustomRecordReferralDetailsPageState
       RecordHFReferralState referralState, IndividualModel? individual) {
     return fb.group(<String, Object>{
       _nameOfChildKey: FormControl<String>(
-        value: referralState.mapOrNull(
-          create: (value) => value.viewOnly &&
-                  value.hfReferralModel?.additionalFields?.fields
-                          .where((e) =>
-                              e.key ==
-                              ReferralReconEnums.nameOfReferral.toValue())
-                          .firstOrNull
-                          ?.value !=
-                      null
-              ? value.hfReferralModel?.additionalFields?.fields
-                  .where((e) =>
-                      e.key == ReferralReconEnums.nameOfReferral.toValue())
-                  .firstOrNull
-                  ?.value
-                  .toString()
-              : value.hfReferralModel?.name ?? '',
-        ),
+        value: individual != null
+            ? _individualDisplayName(individual)
+            : referralState.mapOrNull(
+                create: (value) => value.viewOnly &&
+                        value.hfReferralModel?.additionalFields?.fields
+                                .where((e) =>
+                                    e.key ==
+                                    ReferralReconEnums.nameOfReferral.toValue())
+                                .firstOrNull
+                                ?.value !=
+                            null
+                    ? value.hfReferralModel?.additionalFields?.fields
+                        .where((e) =>
+                            e.key ==
+                            ReferralReconEnums.nameOfReferral.toValue())
+                        .firstOrNull
+                        ?.value
+                        .toString()
+                    : value.hfReferralModel?.name ?? '',
+              ),
         disabled: referralState.mapOrNull(
               create: (value) => value.viewOnly,
             ) ??
@@ -1308,9 +1339,11 @@ class _CustomRecordReferralDetailsPageState
       ),
       _beneficiaryIdKey: FormControl<String>(
         validators: [Validators.required],
-        value: referralState.mapOrNull(
-          create: (value) => value.hfReferralModel?.beneficiaryId,
-        ),
+        value: individual != null
+            ? _individualBeneficiaryId(individual)
+            : referralState.mapOrNull(
+                create: (value) => value.hfReferralModel?.beneficiaryId,
+              ),
         disabled: referralState.mapOrNull(
               create: (value) => value.viewOnly,
             ) ??

--- a/apps/health_campaign_field_worker_app/lib/pages/referral_reconcillation/custom_search_referral_page.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/referral_reconcillation/custom_search_referral_page.dart
@@ -117,14 +117,14 @@ class _CustomSearchReferralReconciliationsPageState
   void _triggerHouseholdSearch(
       BuildContext context, CustomSearchHouseholdsBloc bloc, String value) {
     final trimmed = value.trim();
+    setState(_clearHouseholdSelection);
 
     if (trimmed.isEmpty) {
       bloc.add(const SearchHouseholdsClearEvent());
       return;
     }
 
-    // If input length equals a beneficiary ID, search by tag (ID).
-    if (trimmed.length == _beneficiaryIdLength) {
+    if (_isSearchingByBeneficiaryId(trimmed)) {
       bloc.add(
         CustomSearchHouseholdsEvent.searchByTag(
           tag: trimmed,
@@ -132,7 +132,6 @@ class _CustomSearchReferralReconciliationsPageState
         ),
       );
     } else if (trimmed.length >= 3) {
-      // Otherwise search by name (household head).
       bloc.add(
         CustomSearchHouseholdsEvent.searchByHouseholdHead(
           searchText: trimmed,
@@ -151,6 +150,150 @@ class _CustomSearchReferralReconciliationsPageState
   }
 
   bool _isSideEffectMode = false;
+  HouseholdMemberWrapper? _selectedHouseholdMember;
+  String? _selectedIndividualClientRef;
+
+  bool _isSearchingByBeneficiaryId(String value) =>
+      isBeneficiaryIdValid(value.trim());
+
+  bool isBeneficiaryIdValid(String value) {
+    if (value.trim().length != _beneficiaryIdLength) return false;
+    for (var i = 0; i < value.length; i++) {
+      if ((i == 4 || i == 9) && value[i] != '-') return false;
+      if (value[i].codeUnitAt(0) >= 97 && value[i].codeUnitAt(0) <= 122) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  void _clearHouseholdSelection() {
+    _selectedHouseholdMember = null;
+    _selectedIndividualClientRef = null;
+  }
+
+  String? _beneficiaryIdForIndividual(IndividualModel? individual) {
+    return individual?.identifiers
+        ?.firstWhereOrNull(
+          (id) => id.identifierType == 'UNIQUE_BENEFICIARY_ID',
+        )
+        ?.identifierId;
+  }
+
+  String _fullName(IndividualModel? individual) {
+    return [
+      individual?.name?.givenName,
+      individual?.name?.familyName,
+    ].where((e) => e != null && e.isNotEmpty).join(' ');
+  }
+
+  bool _nameMatches(IndividualModel individual, String query) {
+    final q = query.trim().toUpperCase();
+    if (q.length < 3) return false;
+    final given = individual.name?.givenName?.trim().toUpperCase() ?? '';
+    final family = individual.name?.familyName?.trim().toUpperCase() ?? '';
+    final full = '$given $family'.trim();
+    return given.contains(q) ||
+        family.contains(q) ||
+        full.contains(q) ||
+        q.contains(given) && given.isNotEmpty ||
+        q.contains(family) && family.isNotEmpty;
+  }
+
+  /// Same shape as [searchByTag]: one card per person with tasks/side-effects scoped.
+  HouseholdMemberWrapper _wrapperForIndividual(
+    HouseholdMemberWrapper source,
+    IndividualModel individual,
+  ) {
+    final projectBeneficiaries = source.projectBeneficiaries
+        ?.where(
+          (e) => e.beneficiaryClientReferenceId == individual.clientReferenceId,
+        )
+        .toList();
+    final projectBeneficiaryIds =
+        projectBeneficiaries?.map((e) => e.clientReferenceId).toList() ?? [];
+
+    final tasks = source.tasks
+        ?.where((t) =>
+            projectBeneficiaryIds.contains(t.projectBeneficiaryClientReferenceId))
+        .toList();
+    final taskIds = tasks?.map((t) => t.clientReferenceId).toList() ?? [];
+
+    final sideEffects = source.sideEffects
+        ?.where((s) => taskIds.contains(s.taskClientReferenceId))
+        .toList();
+
+    final referrals = source.referrals
+        ?.where((r) => projectBeneficiaryIds
+            .contains(r.projectBeneficiaryClientReferenceId))
+        .toList();
+
+    return source.copyWith(
+      headOfHousehold: individual,
+      members: [individual],
+      projectBeneficiaries: (projectBeneficiaries?.isEmpty ?? true)
+          ? null
+          : projectBeneficiaries,
+      tasks: (tasks?.isEmpty ?? true) ? null : tasks,
+      sideEffects: (sideEffects?.isEmpty ?? true) ? null : sideEffects,
+      referrals: (referrals?.isEmpty ?? true) ? null : referrals,
+    );
+  }
+
+  /// Tag search: bloc already returns one wrapper per person. Name search: expand here.
+  List<HouseholdMemberWrapper> _sideEffectCardWrappers(
+    CustomSearchHouseholdsState householdState,
+    String query,
+  ) {
+    final trimmed = query.trim();
+    if (trimmed.isEmpty) return [];
+
+    if (_isSearchingByBeneficiaryId(trimmed)) {
+      final upperQuery = trimmed.toUpperCase();
+      return householdState.householdMembers
+          .where((wrapper) {
+            final benefId = _beneficiaryIdForIndividual(
+              wrapper.headOfHousehold ?? wrapper.members?.firstOrNull,
+            );
+            return benefId?.trim().toUpperCase() == upperQuery;
+          })
+          .toList();
+    }
+
+    final seen = <String>{};
+    final cards = <HouseholdMemberWrapper>[];
+
+    for (final wrapper in householdState.householdMembers) {
+      final individuals = <IndividualModel>[
+        ...?wrapper.members,
+        if (wrapper.headOfHousehold != null) wrapper.headOfHousehold!,
+      ];
+
+      var matchedInWrapper = false;
+      for (final individual in individuals) {
+        final clientRef = individual.clientReferenceId;
+        if (clientRef == null || seen.contains(clientRef)) continue;
+        if (!_nameMatches(individual, trimmed)) continue;
+        matchedInWrapper = true;
+        seen.add(clientRef);
+        cards.add(_wrapperForIndividual(wrapper, individual));
+      }
+
+      // Only show head when their name actually matches the query (not as a default).
+      if (!matchedInWrapper && wrapper.headOfHousehold != null) {
+        final head = wrapper.headOfHousehold!;
+        final clientRef = head.clientReferenceId;
+        if (clientRef != null &&
+            !seen.contains(clientRef) &&
+            _nameMatches(head, trimmed)) {
+          seen.add(clientRef);
+          cards.add(_wrapperForIndividual(wrapper, head));
+        }
+      }
+    }
+
+    return cards;
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -199,8 +342,12 @@ class _CustomSearchReferralReconciliationsPageState
                             return BlocBuilder<SearchReferralsBloc,
                                 SearchReferralsState>(
                               builder: (context, searchState) {
+                                final sideEffectCards = _sideEffectCardWrappers(
+                                  householdState,
+                                  searchController.text,
+                                );
                                 final bool beneficiaryFound =
-                                    householdState.householdMembers.isNotEmpty;
+                                    sideEffectCards.isNotEmpty;
 
                                 return ScrollableContent(
                                   header: const Column(children: [
@@ -245,12 +392,14 @@ class _CustomSearchReferralReconciliationsPageState
                                                   Switch(
                                                     value: _isSideEffectMode,
                                                     onChanged: (val) {
-                                                      setInnerState(() =>
-                                                          _isSideEffectMode =
-                                                              val);
-                                                      setState(() =>
-                                                          _isSideEffectMode =
-                                                              val);
+                                                      setInnerState(() {
+                                                        _isSideEffectMode = val;
+                                                        _clearHouseholdSelection();
+                                                      });
+                                                      setState(() {
+                                                        _isSideEffectMode = val;
+                                                        _clearHouseholdSelection();
+                                                      });
                                                       searchController.clear();
                                                       context
                                                           .read<
@@ -286,8 +435,11 @@ class _CustomSearchReferralReconciliationsPageState
                                               ],
                                               controller: searchController,
                                               hintText: localizations.translate(
-                                                i18_local.searchBeneficiary
-                                                    .searchBeneficiaryReferralHintText,
+                                                _isSideEffectMode
+                                                    ? i18_local.searchBeneficiary
+                                                        .beneficiarySearchHintText
+                                                    : i18_local.searchBeneficiary
+                                                        .searchBeneficiaryReferralHintText,
                                               ),
                                               textCapitalization:
                                                   TextCapitalization.words,
@@ -328,7 +480,9 @@ class _CustomSearchReferralReconciliationsPageState
                                               if (!householdState.loading &&
                                                   searchController
                                                       .text.isNotEmpty &&
-                                                  !beneficiaryFound)
+                                                  (householdState
+                                                          .resultsNotFound ||
+                                                      !beneficiaryFound))
                                                 InfoCard(
                                                   title: localizations.translate(
                                                       i18.referralReconciliation
@@ -339,69 +493,6 @@ class _CustomSearchReferralReconciliationsPageState
                                                           .referralReconciliation
                                                           .referralInfoDescription),
                                                 ),
-                                              if (beneficiaryFound)
-                                                ...householdState
-                                                    .householdMembers
-                                                    .where((wrapper) {
-                                                  // Only show the card whose
-                                                  // UNIQUE_BENEFICIARY_ID
-                                                  // matches the typed tag.
-                                                  final ind =
-                                                      wrapper.headOfHousehold ??
-                                                          wrapper.members
-                                                              ?.firstOrNull;
-                                                  final benefId =
-                                                      ind?.identifiers
-                                                          ?.firstWhereOrNull(
-                                                            (id) =>
-                                                                id.identifierType ==
-                                                                'UNIQUE_BENEFICIARY_ID',
-                                                          )
-                                                          ?.identifierId;
-                                                  return benefId
-                                                          ?.trim()
-                                                          .toUpperCase() ==
-                                                      searchController.text
-                                                          .trim()
-                                                          .toUpperCase();
-                                                }).map((wrapper) {
-                                                  final ind =
-                                                      wrapper.headOfHousehold ??
-                                                          wrapper.members
-                                                              ?.firstOrNull;
-                                                  final fullName = [
-                                                    ind?.name?.givenName,
-                                                    ind?.name?.familyName,
-                                                  ]
-                                                      .where((e) =>
-                                                          e != null &&
-                                                          e.isNotEmpty)
-                                                      .join(' ');
-                                                  final identifierId =
-                                                      ind?.identifiers
-                                                          ?.firstWhereOrNull(
-                                                            (id) =>
-                                                                id.identifierType ==
-                                                                'UNIQUE_BENEFICIARY_ID',
-                                                          )
-                                                          ?.identifierId;
-                                                  return _BeneficiarySideEffectCard(
-                                                    name: fullName.isNotEmpty
-                                                        ? fullName
-                                                        : '—',
-                                                    beneficiaryId:
-                                                        identifierId ?? '—',
-                                                    taskCount:
-                                                        wrapper.tasks?.length ??
-                                                            0,
-                                                    hasSideEffects: wrapper
-                                                            .sideEffects
-                                                            ?.isNotEmpty ==
-                                                        true,
-                                                    localizations:
-                                                        localizations,
-                                                  );
-                                                }).toList(),
                                             ],
 
                                             // ── Referral mode: info card ──
@@ -423,6 +514,58 @@ class _CustomSearchReferralReconciliationsPageState
                                         ),
                                       ),
                                     ),
+
+                                    // ── Side-effect mode: beneficiary cards ──
+                                    if (_isSideEffectMode && beneficiaryFound)
+                                      SliverList(
+                                        delegate:
+                                            SliverChildBuilderDelegate(
+                                          (ctx, index) {
+                                            final wrapper =
+                                                sideEffectCards[index];
+                                            final ind =
+                                                wrapper.headOfHousehold ??
+                                                    wrapper.members
+                                                        ?.firstOrNull;
+                                            final fullName = _fullName(ind);
+                                            final identifierId =
+                                                _beneficiaryIdForIndividual(ind);
+                                            final isSelected =
+                                                _selectedIndividualClientRef ==
+                                                    ind?.clientReferenceId;
+                                            return _BeneficiarySideEffectCard(
+                                              name: fullName.isNotEmpty
+                                                  ? fullName
+                                                  : '—',
+                                              beneficiaryId:
+                                                  identifierId ?? '—',
+                                              taskCount:
+                                                  wrapper.tasks?.length ?? 0,
+                                              hasSideEffects: wrapper
+                                                      .sideEffects
+                                                      ?.isNotEmpty ==
+                                                  true,
+                                              isSelected: isSelected,
+                                              localizations: localizations,
+                                              onTap: () {
+                                                setInnerState(() {
+                                                  _selectedHouseholdMember =
+                                                      wrapper;
+                                                  _selectedIndividualClientRef =
+                                                      ind?.clientReferenceId;
+                                                });
+                                                setState(() {
+                                                  _selectedHouseholdMember =
+                                                      wrapper;
+                                                  _selectedIndividualClientRef =
+                                                      ind?.clientReferenceId;
+                                                });
+                                              },
+                                            );
+                                          },
+                                          childCount: sideEffectCards.length,
+                                        ),
+                                      ),
 
                                     // ── Referral mode: results list ──
                                     if (!_isSideEffectMode)
@@ -488,11 +631,15 @@ class _CustomSearchReferralReconciliationsPageState
                               BlocBuilder<CustomSearchHouseholdsBloc,
                                   CustomSearchHouseholdsState>(
                                 builder: (context, hsState) {
-                                  final wrapper =
-                                      hsState.householdMembers.firstOrNull;
+                                  final cards = _sideEffectCardWrappers(
+                                    hsState,
+                                    searchController.text,
+                                  );
+                                  final wrapper = _selectedHouseholdMember ??
+                                      (cards.length == 1 ? cards.first : null);
 
-                                  final ind = wrapper?.headOfHousehold ??
-                                      wrapper?.members?.firstOrNull;
+                                  // Scoped wrapper always stores the selected person here.
+                                  final ind = wrapper?.headOfHousehold;
 
                                   final projectBeneficiaryId = wrapper
                                       ?.projectBeneficiaries
@@ -529,22 +676,10 @@ class _CustomSearchReferralReconciliationsPageState
                                                     HFReferralModel(
                                                   clientReferenceId:
                                                       IdGen.i.identifier,
-                                                  name: [
-                                                    ind!.name?.givenName,
-                                                    ind!.name?.familyName,
-                                                  ]
-                                                      .where((s) =>
-                                                          s != null &&
-                                                          s.isNotEmpty)
-                                                      .join(' '),
+                                                  name: _fullName(ind),
                                                   beneficiaryId:
-                                                      ind!.identifiers
-                                                          ?.firstWhereOrNull(
-                                                            (id) =>
-                                                                id.identifierType ==
-                                                                'UNIQUE_BENEFICIARY_ID',
-                                                          )
-                                                          ?.identifierId,
+                                                      _beneficiaryIdForIndividual(
+                                                          ind),
                                                   additionalFields:
                                                       HFReferralAdditionalFields(
                                                     version: 1,
@@ -633,6 +768,8 @@ class _BeneficiarySideEffectCard extends StatelessWidget {
   final String beneficiaryId;
   final int taskCount;
   final bool hasSideEffects;
+  final bool isSelected;
+  final VoidCallback? onTap;
   final dynamic localizations;
 
   const _BeneficiarySideEffectCard({
@@ -640,6 +777,8 @@ class _BeneficiarySideEffectCard extends StatelessWidget {
     required this.beneficiaryId,
     required this.taskCount,
     this.hasSideEffects = false,
+    this.isSelected = false,
+    this.onTap,
     this.localizations,
   });
 
@@ -650,9 +789,20 @@ class _BeneficiarySideEffectCard extends StatelessWidget {
 
     return Card(
       margin: EdgeInsets.symmetric(vertical: theme.spacerTheme.spacer2),
-      elevation: 2,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-      child: Padding(
+      elevation: isSelected ? 4 : 2,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(8),
+        side: BorderSide(
+          color: isSelected
+              ? theme.colorTheme.primary.primary2
+              : Colors.transparent,
+          width: isSelected ? 2 : 0,
+        ),
+      ),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(8),
+        child: Padding(
         padding: EdgeInsets.all(theme.spacerTheme.spacer4),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -707,6 +857,7 @@ class _BeneficiarySideEffectCard extends StatelessWidget {
             ],
           ],
         ),
+      ),
       ),
     );
   }

--- a/apps/health_campaign_field_worker_app/lib/pages/registration_delivery/custom_household_overview.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/registration_delivery/custom_household_overview.dart
@@ -694,7 +694,7 @@ class _CustomHouseholdOverviewPageState
                                             )
                                           : const Offstage(),
                                       Offstage(
-                                        offstage: isClosedHousehold,
+                                        offstage: false,
                                         child: Column(
                                           children: (state
                                                       .householdMemberWrapper
@@ -1134,7 +1134,7 @@ class _CustomHouseholdOverviewPageState
                                     ],
                                   ),
                                   Offstage(
-                                    offstage: isClosedHousehold,
+                                    offstage: false,
                                     child: DigitButton(
                                       mainAxisSize: MainAxisSize.max,
                                       onPressed: () {

--- a/apps/health_campaign_field_worker_app/lib/pages/registration_delivery/custom_individual_details.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/registration_delivery/custom_individual_details.dart
@@ -1374,15 +1374,38 @@ class CustomIndividualDetailsPageState
       ),
     );
 
-    List<IdentifierModel>? identifiers = individual.identifiers;
-    if (isEditIndividual == false) {
-      identifiers?.add(IdentifierModel(
-        clientReferenceId: individual.clientReferenceId,
-        identifierId: beneficiaryId,
-        identifierType: IdentifierTypes.uniqueBeneficiaryID.toValue(),
-        clientAuditDetails: individual.clientAuditDetails,
-        auditDetails: individual.auditDetails,
-      ));
+    final hasUniqueBeneficiaryId = individual.identifiers?.any(
+          (e) =>
+              e.identifierType ==
+              IdentifierTypes.uniqueBeneficiaryID.toValue(),
+        ) ??
+        false;
+
+    final List<IdentifierModel> resolvedIdentifiers;
+    if (isEditIndividual) {
+      resolvedIdentifiers = List<IdentifierModel>.from(
+        individual.identifiers ?? [],
+      );
+      if (!hasUniqueBeneficiaryId && beneficiaryId != null) {
+        resolvedIdentifiers.add(
+          IdentifierModel(
+            clientReferenceId: individual.clientReferenceId,
+            tenantId: RegistrationDeliverySingleton().tenantId,
+            rowVersion: 1,
+            identifierId: beneficiaryId,
+            identifierType: IdentifierTypes.uniqueBeneficiaryID.toValue(),
+            clientAuditDetails: individual.clientAuditDetails,
+            auditDetails: individual.auditDetails,
+          ),
+        );
+      }
+    } else {
+      resolvedIdentifiers = [
+        identifier.copyWith(
+          identifierId: beneficiaryId,
+          identifierType: IdentifierTypes.uniqueBeneficiaryID.toValue(),
+        ),
+      ];
     }
 
     String? individualName = form.control(_individualNameKey).value as String?;
@@ -1396,14 +1419,7 @@ class CustomIndividualDetailsPageState
               .byName(form.control(_genderKey).value.toString().toLowerCase()),
       mobileNumber: form.control(_mobileNumberKey).value,
       dateOfBirth: dobString,
-      identifiers: isEditIndividual && identifier.identifierId != null
-          ? identifiers
-          : [
-              identifier.copyWith(
-                identifierId: beneficiaryId,
-                identifierType: IdentifierTypes.uniqueBeneficiaryID.toValue(),
-              ),
-            ],
+      identifiers: resolvedIdentifiers,
       additionalFields: IndividualAdditionalFields(
         version: 1,
         fields: [

--- a/apps/health_campaign_field_worker_app/lib/utils/i18_key_constants.dart
+++ b/apps/health_campaign_field_worker_app/lib/utils/i18_key_constants.dart
@@ -321,6 +321,10 @@ class EditTasks {
   String get additionalDetailsSectionTitle =>
       'ADDITIONAL_DETAILS_SECTION_TITLE';
 
+  String get editableFieldsHintTitle => 'EDIT_TASKS_EDITABLE_FIELDS_HINT_TITLE';
+
+  String get editableFieldBadge => 'EDIT_TASKS_EDITABLE_FIELD_BADGE';
+
   String get schemaLabel => 'SCHEMA_LABEL';
 
   String get versionLabel => 'VERSION_LABEL';


### PR DESCRIPTION
…accine navigation

Allow editing task fields on the task details screen. Skip follow-up questions when RDT is positive. Correct closed-household handling in registration delivery. Enable beneficiary search by name for side-effect recording and show the selected child (not the household head) on referral details. After saving vaccines, return to the prior screen instead of restarting at the household overview.